### PR TITLE
Strip Jupyter notebooks

### DIFF
--- a/demo.ipynb
+++ b/demo.ipynb
@@ -902,6 +902,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "d0361ec4",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -909,6 +910,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "64f92440",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -916,6 +918,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "7e6dd179",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -923,6 +926,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "770d1b12",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -930,13 +934,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "4f0d11d1",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "6c75aaf5-516f-432e-a57b-b4e7fa4d7fad",
+   "id": "546df2a6",
    "metadata": {
     "tags": []
    },
@@ -947,7 +952,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "31f24326-c47f-4afe-b1bc-d29e3f59600a",
+   "id": "f86298e2",
    "metadata": {
     "tags": []
    },
@@ -959,7 +964,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6944588a-a674-4522-85d0-edb5eca892b6",
+   "id": "b6640c2c",
    "metadata": {
     "tags": []
    },
@@ -975,22 +980,14 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
    "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
+    "name": "ipython"
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.10.9"
+   "nbconvert_exporter": "python"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The `demo.ipynb` was not stripped according to the ssb-gitconfig settings, se [recommended gitconfig]( https://github.com/statisticsnorway/kvakk-git-tools/blob/2efe5407d4f624bd372864e8057a3e4d542f6804/kvakk_git_tools/recommended/gitconfig-dapla#L13-L16).

Using no or different stripping is causing problems, because the file is listed as changed, but git diff show no changes. And sometimes you can't even switch branches because of this, not even `git reset --hard HEAD` works. The problem and solution is described at [this page](https://statistics-norway.atlassian.net/wiki/spaces/A700/pages/3211952133/Git+status+viser+endrede+filer+men+git+diff+viser+ingen+endring#Nbstripout).

This PR fixes the file. To avoid the same problem in the future all users (or at least all committers) should use the same stripping config as listed above.
